### PR TITLE
chore: Remove deprecated 'bottle: unneeded' from kubeval formula

### DIFF
--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -2,7 +2,6 @@ class Kubeval < Formula
   desc "Validate your Kubernetes configurations"
   homepage "https://github.com/instrumenta/kubeval"
   version "0.16.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-darwin-amd64.tar.gz"


### PR DESCRIPTION
Self explanatory.
See also: Homebrew/brew#11239