### PR TITLE
chore: Bump notekeeper to 1.2

### DIFF
--- a/Formula/notekeeper.rb
+++ b/Formula/notekeeper.rb
@@ -3,9 +3,9 @@ require 'formula'
 class Notekeeper < Formula
   desc "Notekeeper: A tiny bash tool for taking and organizing simple text notes."
   homepage "https://github.com/dcchambers/note-keeper"
-  url "https://github.com/dcchambers/note-keeper/releases/download/v1.1/notekeeper.tar.gz"
-  sha256 "6454637dcc985bbaebae4ac7c0fb35b6b057f796b67439fa89bb6c4d7b4c26e5"
-  version "1.1"
+  url "https://github.com/dcchambers/note-keeper/releases/download/v1.2/notekeeper.tar.gz"
+  sha256 "5d2006b904d7bfae573019111d9f417087cd7956ce6f98353b5ceee1ad7344cb"
+  version "1.2"
   license "MIT"
 
   def install


### PR DESCRIPTION
- https://github.com/dcchambers/note-keeper/releases/tag/v1.2